### PR TITLE
Update bP32-validators.html

### DIFF
--- a/htmlDocs/B1/bP32-validators.html
+++ b/htmlDocs/B1/bP32-validators.html
@@ -20,9 +20,7 @@
         <li>Consistent Goldilock Slot Positions: &gt; decentralization, &lt; unelection risk.<br></li>
         <li>Additional : Experience & Equipment<br><br></li>
       </ul>
-        The portfolio reserves 9 spots for the active Harmony Validator DAO Governors.<br>
-        The 23 remaining are assigned based on bP32 criteria, monitored daily and reevaluated each quarter.<br><br>
-
+       
         <h3>FAQ:</h3>
         <h4>Why isn't current expected return a criteria?</h4>
         The bP32 criteria results in consistent expected returns. The expected return itself, as displayed on staking portals, is a poor indicator of future performance.
@@ -34,11 +32,6 @@
         The minimum fee a validator can charge on staking rewards is 5%. We monitor validator costs & rewards to insure bP32 validators are incentivized to
         continue providing best in class service and support without negatively affecting investor returns. There are no other fees assessed on transactions
         besides regular gas fees.
-
-        <h4>What or who is a Validator DAO Governor?</h4>
-        They are among the most active and trustworthy in the validator community and critical to the infrastructure and future viability of the Harmony Ecosystem.
-
-
 
 
       </p>


### PR DESCRIPTION
removed VDAO govs as required, redundant based on criteria